### PR TITLE
chore: Added default users and passwords to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ Pylint (checking code conforms to PEP standards) is run with the following comma
 ```bash
 poetry run lint
 ```
+
+## Current Credentials
+With the database in its current state, the usernames can be seen in the following list, all passwords are set to `Password123!`
+
+| Email                      | Roles                                            |
+| -------------------------- | ------------------------------------------------ |
+| kim62@example.net          | Admin (All roles)                                |
+| yparker@example.org        | Manager (All roles except User management roles) |
+| ymccarthy@example.org      | User (ReadAsset, RequestAsset)                   |
+| davidsoto@example.org      | User (ReadAsset, RequestAsset)                   |
+| rebeccashields@example.org | User (ReadAsset, RequestAsset)                   |
+| carolwells@example.com     | User (ReadAsset, RequestAsset)                   |
+| itravis@example.org        | User (ReadAsset, RequestAsset)                   |
+| kathrynhall@example.com    | User (ReadAsset, RequestAsset)                   |
+| dianaparks@example.org     | User (ReadAsset, RequestAsset)                   |
+| zimmermansusan@example.com | User (ReadAsset, RequestAsset)                   |


### PR DESCRIPTION
Added the credentials for users who exist in the current fake seeded database so users can test without needing to seed and lookup users