### PR TITLE
fix: Fixed 500 when updating unique values

### DIFF
--- a/asset_manager/repositories/asset_repo.py
+++ b/asset_manager/repositories/asset_repo.py
@@ -29,6 +29,13 @@ class AssetRepository(AbstractCRUDRepo[Asset]):
 
         return self.db.query(Asset).filter(*filters).all()
 
+    def get_by_asset_tag(
+        self,
+        tag: str,
+    ) -> Optional[Asset]:
+        """Get asset by its tag"""
+        return self.db.query(Asset).filter(Asset.asset_tag == tag).first()
+
     def get_due_for_maintenance(
         self, subquery: Optional[ColumnExpressionArgument[bool]] = None
     ) -> list[Asset]:

--- a/asset_manager/routes/assets.py
+++ b/asset_manager/routes/assets.py
@@ -87,6 +87,12 @@ def create_asset(
     label_repo = LabelRepository(db)
     label_mapping_repo = LabelMappingAssetRepository(db)
 
+    if repo.get_by_asset_tag(asset.asset_tag):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Asset Tag must be Unique",
+        )
+
     labels = [label_repo.get_by_name(label_name) for label_name in asset.labels]
     if any(label is None for label in labels):
         raise HTTPException(
@@ -187,6 +193,13 @@ def update_asset(
     """Update the information about an asset in the database"""
     repo = AssetRepository(db)
     asset = asset_exists(asset_id, repo)
+
+    if data.asset_tag and data.asset_tag != asset.asset_tag:
+        if repo.get_by_asset_tag(data.asset_tag):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Asset Tag must be Unique",
+            )
 
     labels = [label.name for label in asset.labels]
     if not has_role(current_user, "CreateEditAsset", labels):

--- a/asset_manager/routes/labels.py
+++ b/asset_manager/routes/labels.py
@@ -79,7 +79,7 @@ def create_label(
         "select",
         "labels",
         current_user.email,
-        f"Tried to create label {label.id} but it already exited",
+        f"Tried to create label {label.id} but it already existed",
     )
     return cast_to_pydantic(label, LabelSchema)
 

--- a/asset_manager/routes/user.py
+++ b/asset_manager/routes/user.py
@@ -113,6 +113,17 @@ def create_user(
     label_repo = LabelRepository(db)
     label_mapping_repo = LabelMappingUserRepository(db)
 
+    if repo.get_by_email(data.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email must be Unique",
+        )
+    if repo.get_by_name(data.name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Name must be Unique",
+        )
+
     labels = [label_repo.get_by_name(label_name) for label_name in data.labels]
     if any(label is None for label in labels):
         raise HTTPException(


### PR DESCRIPTION
When updating Assets and Users, if the UNIQUE contraint failed it would return 500, now it returns 400 with a contextual error